### PR TITLE
Restore original dimension order when no optimal order found

### DIFF
--- a/optimuspy.py
+++ b/optimuspy.py
@@ -187,6 +187,7 @@ def main(instance_name: str, cube_name: str, view_name: str, process_name: str, 
                 best_permutation = optimus_result.best_result
                 logging.info(f"Completed analysis for cube '{cube_name}'")
                 if not best_permutation:
+                    tm1.cubes.update_storage_dimension_order(cube_name, original_dimension_order)
                     logging.info(
                         f"No ideal dimension order found for cube '{cube_name}'."
                         f"Please pick manually based on csv and png results.")


### PR DESCRIPTION
In the current OptimusPy implementation, if an optimal dimension order isn't identified for a TM1 cube, the script alters the cube's dimension order to the last tested configuration. This behaviour might be confusing. 
I've made a change that ensures the TM1 cube's original dimension order is preserved unless a definitive improvement is found.