### PR TITLE
Bug/fix gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    pull-request-branch-name:
+      separator: "/"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "nicolasbisurgi"
+    open-pull-requests-limit: 5
+
+  # Enable version updates for Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    pull-request-branch-name:
+      separator: "/"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+    reviewers:
+      - "nicolasbisurgi"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
       - "github-actions"
     reviewers:
       - "nicolasbisurgi"
+      - "MariusWirtz"
+      # Add more individual reviewers:
+      # - "username2"
+      # - "username3"
+      # Or assign to teams (use org/team-name format):
+      # - "myorg/backend-team"
+      # - "myorg/devops"
     open-pull-requests-limit: 5
 
   # Enable version updates for Python dependencies
@@ -36,4 +43,11 @@ updates:
       - "python"
     reviewers:
       - "nicolasbisurgi"
+      - "MariusWirtz"
+      # Add more individual reviewers:
+      # - "username2"
+      # - "username3"
+      # Or assign to teams (use org/team-name format):
+      # - "myorg/backend-team"
+      # - "myorg/devops"
     open-pull-requests-limit: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -45,7 +45,7 @@ jobs:
           --console .\optimuspy.py
 
       - name: Upload executable artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: optimuspy-winOS
           path: dist/optimuspy.exe


### PR DESCRIPTION
  1. Updated the deprecated GitHub Actions in .github/workflows/build.yml:
    - actions/checkout@v3 → actions/checkout@v4
    - actions/setup-python@v4 → actions/setup-python@v5
    - actions/upload-artifact@v3 → actions/upload-artifact@v4
  2. Created .github/dependabot.yml that will:
    - Automatically check for GitHub Actions updates weekly
    - Automatically check for Python dependency updates weekly
    - Create PRs with proper labels and commit message prefixes
    - Assigns reviewers (individual and groups within the GH Org)
    - Limit open PRs to 5 for each ecosystem

PoC:  Dependabot will now scan the repository weekly (every Monday at 9 AM) and create pull requests whenever it finds
  outdated dependencies or GitHub Actions.