### PR TITLE
Automate executable build and attach to GitHub releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
   build-windows:
     name: Build on Windows
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,19 +26,72 @@ jobs:
           pip install pyinstaller
           pip install -r requirements.txt
 
-      - name: Build executable
+      - name: Generate PyInstaller spec file
         run: |
-          pyinstaller --onefile `
-          --name "optimuspy" `
-          --add-data "execution_mode.py;." `
-          --add-data "executors.py;." `
-          --add-data "results.py;." `
-          --hidden-import "seaborn" `
-          --console optimuspy.py
+          $specContent = @"
+          # -*- mode: python ; coding: utf-8 -*-
+
+          a = Analysis(
+              ['optimuspy.py'],
+              pathex=[],
+              binaries=[],
+              datas=[('execution_mode.py', '.'), ('executors.py', '.'), ('results.py', '.')],
+              hiddenimports=['seaborn', 'execution_mode', 'executors', 'results','win32timezone'],
+              hookspath=[],
+              hooksconfig={},
+              runtime_hooks=[],
+              excludes=[],
+              noarchive=False,
+              optimize=0,
+          )
+          pyz = PYZ(a.pure)
+
+          exe = EXE(
+              pyz,
+              a.scripts,
+              a.binaries,
+              a.datas,
+              [],
+              name='optimuspy',
+              debug=False,
+              bootloader_ignore_signals=False,
+              strip=False,
+              upx=True,
+              upx_exclude=[],
+              runtime_tmpdir=None,
+              console=True,
+              disable_windowed_traceback=False,
+              argv_emulation=False,
+              target_arch=None,
+              codesign_identity=None,
+              entitlements_file=None,
+          )
+          "@
+          Set-Content -Path "optimuspy.spec" -Value $specContent
+
+      - name: Build executable
+        run: pyinstaller optimuspy.spec
 
       - name: Upload executable artifact
         uses: actions/upload-artifact@v4
         with:
-          name: optimuspy-winOS
+          name: optimuspy-windows
           path: dist/optimuspy.exe
           retention-days: 180
+
+      - name: Attach to latest release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/optimuspy.exe
+          tag_name: latest
+          name: Latest Build
+          body: |
+            Latest Windows executable build from master branch.
+
+            **Download:** optimuspy.exe
+
+            This executable is automatically built and updated on every merge to master.
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
-.idea
+.idea/
+dist/
+.venv/
+build/
+__pycache__/
+*.pyc
+*.spec
+results/
+*.log

--- a/execution_mode.py
+++ b/execution_mode.py
@@ -13,3 +13,13 @@ class ExecutionMode(Enum):
                 return member
         # default
         return cls.ALL
+
+    @property
+    def label(self) -> str:
+        """Return human-readable label for the execution mode."""
+        labels = {
+            ExecutionMode.ORIGINAL_ORDER: "Original Order",
+            ExecutionMode.ITERATIONS: "Iterations",
+            ExecutionMode.RESULT: "Result",
+        }
+        return labels.get(self, self.name)

--- a/optimuspy.py
+++ b/optimuspy.py
@@ -41,7 +41,6 @@ def set_current_directory():
     os.chdir(directory)
     return directory
 
-
 def configure_logging():
     logging.basicConfig(
         filename=LOGFILE,

--- a/results.py
+++ b/results.py
@@ -93,14 +93,12 @@ class PermutationResult:
         return SEPARATOR.join(self.build_header()) + "\n"
 
     def to_row(self, view_name: str, process_name: str, original_order_result: 'PermutationResult') -> List[str]:
-        from optimuspy import LABEL_MAP
-
         median_query_time = float(self.median_query_time(view_name))
         original_median_query_time = float(original_order_result.median_query_time(view_name))
         query_time_ratio = median_query_time / original_median_query_time - 1
         row = [
             str(self.permutation_id),
-            LABEL_MAP[self.mode],
+            self.mode.label,
             str(self.is_best),
             median_query_time,
             query_time_ratio]
@@ -250,8 +248,6 @@ class OptimusResult:
 
     @property
     def original_order_result(self) -> PermutationResult:
-        from optimuspy import ExecutionMode
-
         for result in self.permutation_results:
             if result.mode == ExecutionMode.ORIGINAL_ORDER:
                 return result


### PR DESCRIPTION
- Updated GitHub Actions workflow to dynamically generate PyInstaller spec file during build
- Configured workflow to automatically attach Windows executable to 'latest' release on master merges
- Added label property to ExecutionMode enum for cleaner display formatting
- Refactored results.py to use mode.label property, removing LABEL_MAP circular import
- Enhanced .gitignore to exclude build artifacts, spec files, results, and log files