### PR TITLE
Add Linux executable build to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,6 @@ jobs:
   build-windows:
     name: Build on Windows
     runs-on: windows-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -43,3 +41,40 @@ jobs:
           name: Build ${{ steps.sha.outputs.short }}
           body: "Automated build from commit ${{ github.sha }}"
           files: dist/optimuspy.exe
+
+  build-linux:
+    name: Build on Linux
+    needs: build-windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -r requirements.txt
+
+      - name: Build executable
+        run: pyinstaller optimuspy.spec
+
+      - name: Rename binary
+        run: mv dist/optimuspy dist/optimuspy-linux
+
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: build-${{ steps.sha.outputs.short }}
+          name: Build ${{ steps.sha.outputs.short }}
+          body: "Automated build from commit ${{ github.sha }}"
+          files: dist/optimuspy-linux

--- a/optimuspy.spec
+++ b/optimuspy.spec
@@ -1,12 +1,16 @@
 # -*- mode: python ; coding: utf-8 -*-
+import sys
 
+hiddenimports = ['seaborn', 'execution_mode', 'executors', 'results']
+if sys.platform == 'win32':
+    hiddenimports.append('win32timezone')
 
 a = Analysis(
     ['optimuspy.py'],
     pathex=[],
     binaries=[],
     datas=[('execution_mode.py', '.'), ('executors.py', '.'), ('results.py', '.')],
-    hiddenimports=['seaborn', 'execution_mode', 'executors', 'results','win32timezone'],
+    hiddenimports=hiddenimports,
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],


### PR DESCRIPTION
## Summary
- Add a `build-linux` job to the GitHub Actions workflow that produces an `optimuspy-linux` binary
- Both Windows (`optimuspy.exe`) and Linux (`optimuspy-linux`) assets are attached to the same release
- Make `optimuspy.spec` platform-aware: `win32timezone` is only included on Windows
- Linux job runs after Windows job (`needs: build-windows`) to avoid release creation race conditions

## Test plan
- [ ] Verify the workflow runs successfully on a merge to master
- [ ] Confirm both `optimuspy.exe` and `optimuspy-linux` appear as release assets
- [ ] Verify the Linux binary runs on a Linux machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)