### PR TITLE
feat(metrics): source per-cube RAM from MetricService for v11 + v12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ configs/
 test.py
 CLAUDE.md
 
+# v11/v12 parity validation snapshots (run artifacts; logs already covered by *.log)
+parity.json
+v11_before.json
+v11_after.json
+
 # mkdocs build output
 mkdocs_site/
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,41 @@
+# OptimusPy
+
+OptimusPy benchmarks TM1 cube dimension-storage orders to find the order that minimises RAM (and/or query time). It reorders a cube's storage dimensions, measures the resulting per-cube memory, and reports the best permutation.
+
+## Language
+
+### Memory measurement
+
+**RAM baseline**:
+The per-cube memory figure OptimusPy reads before and after each permutation to decide which order is best. Always held internally in **bytes**.
+_Avoid_: "memory footprint", "size"
+
+**cube_memory_used**:
+The canonical MetricService metric name for a cube's total memory. Replaces the v11-only `StatsByCube` → `Total Memory Used` lookup. Version-agnostic in *name*, but its `Unit` differs by server version.
+_Avoid_: "Total Memory Used" (that is the v11 MDX measure, now an implementation detail behind the metric)
+
+**MetricService**:
+The version-agnostic TM1py service (`tm1.metrics`, TM1py ≥ 2.3.0) that serves model statistics. `by_cube()` returns per-cube gauge rows; OptimusPy uses it as the single source of RAM data on both v11 and v12.
+_Avoid_: "StatsByCube" / "PerfCubes" (v11 control cubes, now hidden behind MetricService)
+
+**Unit (of a metric)**:
+The unit tag MetricService attaches to each metric value (`B`, `KB`, `MB`, `#`, `%`…). MetricService normalises metric *names* across versions but **not** units — `cube_memory_used` is `B` on v11 and `KB` on v12. Callers must read `Unit` and convert to bytes.
+_Avoid_: assuming a fixed unit; hardcoding `×1024`
+
+## Relationships
+
+- A **permutation** (storage dimension order) produces one **RAM baseline** reading via **cube_memory_used**
+- **cube_memory_used** is served by **MetricService**, carrying a **Unit** that must be converted to bytes at the read boundary
+
+## Scope of the v12 migration
+
+Behavior is **frozen** — only the *data source* changes. The RAM model is unchanged: read a **RAM baseline** once at the start, then derive every other permutation's RAM by applying the `%` change that `update_storage_dimension_order` returns (confirmed to return a real `%` on v11 **and** v12). OptimusPy does **not** read per-permutation memory from the server. The migration swaps the `}StatsByCube` MDX reads for `MetricService.by_cube()` reads. On v11 the Performance Monitor must still be active before reading (toggled via `tm1.metrics` lifecycle methods); on v12 nothing is toggled because the metric is always available. The VMM/VMT cap raise-and-restore is v11-only too — it reads/writes the `}CubeProperties` control cube, which does not exist on v12, so optimize mode simply skips it there.
+
+## Flagged ambiguities
+
+- "RAM" / "memory" was used loosely — resolved: OptimusPy's internal canonical unit is **bytes**; conversion from the metric's reported **Unit** happens once, at the read boundary, so all downstream `/ 1024**3` GB math is unchanged.
+
+## Example dialogue
+
+> **Dev:** "After a permutation, where do we get the new **RAM baseline**?"
+> **Domain expert:** "From **MetricService** `by_cube()` — read the `cube_memory_used` row, then convert by its **Unit**: `B`→×1, `KB`→×1024. Never assume bytes; v12 reports KB."

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Find the ideal dimension order for your TM1 cubes
 
+Supported versions: TM1 v11 and v12 (PAoC/PAaaS).
+
 ## Installing
 
 Install required python packages:

--- a/docs/adr/0001-metricservice-replaces-statsbycube.md
+++ b/docs/adr/0001-metricservice-replaces-statsbycube.md
@@ -1,0 +1,29 @@
+# MetricService replaces the }StatsByCube cube as OptimusPy's RAM source
+
+## Context
+
+OptimusPy reads per-cube memory to choose the best dimension-storage order. It did this by querying the `}StatsByCube` control cube via MDX (`Total Memory Used`), which only exists on TM1 v11 — the cube was deprecated in v12, so OptimusPy could not run there at all.
+
+## Decision
+
+Read RAM from the version-agnostic TM1py `MetricService` (`tm1.metrics.by_cube()`, TM1py ≥ 2.3.0), using the `cube_memory_used` metric, on both v11 and v12.
+
+Three things make this non-obvious and are deliberate:
+
+1. **Convert via the `Unit` column — never assume a fixed unit.** MetricService normalizes metric *names* across versions but **not** their units: `cube_memory_used` is reported in `B` on v11 and `KB` on v12 (and sibling memory metrics differ again). OptimusPy converts whatever `by_cube()` returns into **bytes** at the read boundary (`B→×1`, `KB→×1024`, `MB→×1024²`; unknown unit fails loud), so all downstream `/1024**3` GB math is untouched. Hardcoding `×1024` would silently break on a unit change — do not "simplify" the `Unit` branch away.
+
+2. **Behavior is otherwise frozen.** The RAM model is unchanged: read the baseline once, then derive every other permutation from the `%` that `update_storage_dimension_order` returns (confirmed to return a real `%` on v11 and v12). OptimusPy does not read per-permutation memory from the server.
+
+3. **Lifecycle and errors are version-gated.** The major version is detected once (`get_product_version()`). On v11 the Performance Monitor must still be active before reading (toggled via `tm1.metrics` lifecycle methods, prior state restored); on v12 nothing is toggled because the metric is always available. The "Performance Monitor must be activated" error and the read-retry/wait loop remain v11-only. The VMM/VMT cap raise-and-restore (read/written via the `}CubeProperties` control cube) is also v11-only — `}CubeProperties` does not exist on v12, so optimize mode skips it there rather than crashing.
+
+4. **The v12 baseline read stabilizes before it is trusted.** On v12, `cube_memory_used` is a sampled gauge that lags right after a data change: a read taken immediately after a load can return a too-small value before the gauge catches up (observed: 40 KB seconds after a load that settled to ~50 MB). Because OptimusPy can't know a cube's true size in advance, the v12 read polls until the value *plateaus* (a re-read no longer materially larger than the largest seen) rather than failing fast. On a settled, resident cube the second read confirms the first and it returns immediately. This only affects the absolute baseline; the chosen order is derived from the `%` deltas and is correct regardless, so if the gauge never fully settles within the bounded attempts the largest sample is used. v11's read path is unchanged (frozen).
+
+## Considered alternatives
+
+- **Hardcode `×1024` for v12.** Rejected: wrong for sibling memory metrics already in bytes, and brittle if the server's reported unit ever changes. Reading the `Unit` column is the contract the service is designed around.
+- **Read `cube_memory_used` per permutation instead of applying the `%`.** Rejected: unnecessary server round-trips and reintroduces sampling-freshness risk, for no benefit over the existing baseline-plus-`%` model.
+
+## Consequences
+
+- OptimusPy now serves TM1 v11 and v12 (PAoC/PAaaS) from a single code path.
+- Validation depends on a live two-instance comparison (identical cube + data on v11 and v12); there is no offline regression guard in CI for the conversion, so the conversion correctness rides on that manual pre-merge gate.

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -14,7 +14,7 @@ OptimusPy benchmarks dimension orders by physically reordering the cube on the T
        b. Clear cube cache
        c. Run each view N times — record query times
        d. Run each process N times — record process times
-       e. Read RAM from }StatsByCube
+       e. Read RAM from the TM1py Metrics service (`cube_memory_used`), version-agnostic across v11 and v12
        f. Save a checkpoint
 5. Pick the best result by composite score
 6. Apply best (if update=true) or restore the original

--- a/docs/concepts/ram-vs-query-tradeoff.md
+++ b/docs/concepts/ram-vs-query-tradeoff.md
@@ -24,7 +24,7 @@ If you don't specify any views, query time is not measured and the result is ran
 
 ## Composite RAM
 
-Just one number: the cube's total memory used after the order is applied (read from `}StatsByCube` → `Total Memory Used`). RAM is measured **after** all queries have run, so it reflects the steady-state footprint.
+Just one number: the cube's total memory used after the order is applied (read from the TM1py Metrics service (`cube_memory_used`), version-agnostic across v11 and v12). RAM is measured **after** all queries have run, so it reflects the steady-state footprint.
 
 ## Picking the best result
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,8 @@
 
 Benchmarks IBM TM1 / Planning Analytics dimension orders against query speed, RAM, and TI execution. Six modes, a local web UI, and an interactive HTML dashboard.
 
+Supported versions: TM1 v11 and v12 (PAoC/PAaaS).
+
 [← Back to the landing page](https://cubewise-code.github.io/optimus-py/){ .back-link }
 </div>
 

--- a/docs/ui/optimize-page.md
+++ b/docs/ui/optimize-page.md
@@ -10,7 +10,7 @@ The Optimize page is the heart of OptimusPy. Connect to an instance, scan for ca
 2. Adjust the **RAM threshold** slider to control how aggressively cubes are filtered (default: 60% of total model RAM).
 3. Toggle **Include Optimized** to also list cubes that already have a custom storage order.
 
-The scan calls `}StatsByCube` on the TM1 server — a single fast MDX query. Results are cached locally for 24 hours; click **Re-scan** to refresh.
+The scan reads from the TM1py Metrics service (`cube_memory_used`), version-agnostic across v11 and v12 — a single fast round-trip. Results are cached locally for 24 hours; click **Re-scan** to refresh.
 
 ## Cube workspace
 

--- a/docs/v2-features.md
+++ b/docs/v2-features.md
@@ -220,7 +220,7 @@ optimuspy scan --instance tm1srv01 --ram-percent 80 --output configs/
 ```
 
 The scan:
-1. Queries `}StatsByCube` for RAM usage across all non-control cubes (including the "Cubes Total" row for total model RAM)
+1. Reads RAM usage across all non-control cubes from the TM1py Metrics service (`cube_memory_used`), version-agnostic across v11 and v12 (the service already excludes `}`-control cubes and the synthetic "Cubes Total" row)
 2. Sorts cubes by RAM descending and selects those that account for up to N% of total model RAM (default: 60%, configurable via `--ram-percent`)
 3. Removes cubes that have already been optimized (where the internal storage order differs from the visible order)
 4. Prints a summary table with each cube's share of total RAM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "TM1py>=1.5.0",
+    "TM1py>=2.3.0",
     "configparser>=3.5.3",
     "mdxpy>=0.2",
     "xlsxwriter",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-TM1py>=1.5.0
+TM1py>=2.3.0
 configparser>=3.5.3
 mdxpy>=0.2
 xlsxwriter

--- a/samples/validate_v11_v12_parity.py
+++ b/samples/validate_v11_v12_parity.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Manual pre-merge gate: prove OptimusPy behaves identically on TM1 v11 and v12.
+
+This is NOT a unit test and is NOT run in CI — it needs two live TM1 instances
+(one v11, one v12) reachable from the same ``config.ini``. It builds a *byte-for
+byte identical* 8-dimension cube, loaded with the *same* seeded random data, on
+both servers, then:
+
+  1. Reads the per-cube RAM baseline (``cube_memory_used``) from each server and
+     reports the raw value + Unit and the converted bytes. Equal post-conversion
+     bytes across versions are the proof that the Unit->bytes conversion is
+     correct (v11 reports ``B``, v12 reports ``KB``).
+  2. Runs every OptimusPy mode (greedy, fast greedy, predefined, position,
+     dimension, set) against both servers and compares the winning storage order
+     each mode picks. Identical data must yield the same winner on both versions.
+  3. Writes a JSON snapshot (``--snapshot``). Run this script on the *pre-change*
+     commit against the v11 instance, keep the snapshot, then run it again on the
+     post-change commit and diff the two snapshots to confirm v11 behaviour is
+     frozen byte-for-byte.
+
+Usage
+-----
+    # config.ini must contain a [v11srv] and a [v12srv] section (any names).
+    python samples/validate_v11_v12_parity.py \
+        --config config/config.ini \
+        --v11 v11srv --v12 v12srv \
+        --snapshot v11_after.json
+
+    # frozen-behaviour check (run on each commit, then diff the snapshots):
+    git stash && python samples/validate_v11_v12_parity.py --config ... \
+        --v11 v11srv --only v11 --snapshot v11_before.json && git stash pop
+    python samples/validate_v11_v12_parity.py --config ... \
+        --v11 v11srv --only v11 --snapshot v11_after.json
+    diff <(jq -S . v11_before.json) <(jq -S . v11_after.json)
+
+Pass ``--cleanup`` to delete the generated cube + dimensions afterwards.
+"""
+import argparse
+import csv
+import glob
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# Make the in-tree package importable when run from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from TM1py import TM1Service, Dimension, Hierarchy, Element, Cube  # noqa: E402
+
+from optimuspy import core  # noqa: E402
+from optimuspy.core import get_tm1_config  # noqa: E402
+from optimuspy.metrics import (  # noqa: E402
+    detect_is_v12, unit_to_bytes, CUBE_MEMORY_METRIC,
+)
+
+# Test-side stabilization. The fixture is read right after a bulk load, when
+# cube_memory_used is still catching up — v11 transiently over-reports, v12
+# under-reports — so settle BOTH versions (poll until the value plateaus) before
+# comparing. This is the test knowing "what the size should be"; the product uses
+# the same idea (target-free plateau) only on v12.
+_SETTLE_ATTEMPTS = 24
+_SETTLE_WAIT_SECONDS = 10
+_SETTLE_TOLERANCE = 0.01
+
+# --- Fixture definition -----------------------------------------------------
+
+CUBE = "OptimusPy_Parity_Test"
+SEED = 20260605  # LCG seed — fixed so v11 and v12 receive byte-identical data
+# 7 sparse dimensions of widely-varying size + 1 numeric measure dimension (last).
+# Varied cardinality + the skewed fill below make storage dimension order actually
+# affect RAM, so a genuine winner emerges (a uniform fill ties on every order).
+DIM_SIZES = {
+    f"{CUBE}_Dim1": 200,
+    f"{CUBE}_Dim2": 160,
+    f"{CUBE}_Dim3": 120,
+    f"{CUBE}_Dim4": 80,
+    f"{CUBE}_Dim5": 50,
+    f"{CUBE}_Dim6": 25,
+    f"{CUBE}_Dim7": 12,
+}
+MEASURE_DIM = f"{CUBE}_Measure"
+MEASURES = ["Value", "Count", "Amount"]
+FILL_CELLS = 300_000  # number of deterministic LCG-driven cell writes (server-side)
+
+
+def _dimension_names():
+    return list(DIM_SIZES.keys()) + [MEASURE_DIM]
+
+
+def _build_dimensions(tm1: TM1Service):
+    # Non-padded element names ('E0', 'E1', ...) so the server-side TI can rebuild
+    # each name with a plain TRIM(STR(idx, 12, 0)) — no zero-pad logic needed.
+    for dim_name, size in DIM_SIZES.items():
+        elements = [Element(f"E{i}", "Numeric") for i in range(size)]
+        hier = Hierarchy(dim_name, dim_name, elements=elements)
+        tm1.dimensions.update_or_create(Dimension(dim_name, [hier]))
+    # measure dimension: numeric measures only (keeps it last-position legal)
+    elements = [Element(m, "Numeric") for m in MEASURES]
+    hier = Hierarchy(MEASURE_DIM, MEASURE_DIM, elements=elements)
+    tm1.dimensions.update_or_create(Dimension(MEASURE_DIM, [hier]))
+
+
+def _build_cube(tm1: TM1Service):
+    tm1.cubes.update_or_create(Cube(CUBE, _dimension_names()))
+
+
+def _ti_fill_prolog():
+    """Generate TI prolog that fills the cube with deterministic, skewed sparse data.
+
+    Pushing 300k cells from the client tripped a v12 request-memory cap, so the fill
+    runs server-side instead. A MINSTD LCG (integer math, identical on every IEEE
+    double engine) makes v11 and v12 produce byte-identical data without RAND().
+    A square-skew on each index concentrates density toward low elements so RAM
+    genuinely depends on dimension order.
+    """
+    lines = [
+        f"sCube = '{CUBE}';",
+        f"nState = {SEED};",
+        f"nCells = {FILL_CELLS};",
+        "nM = 2147483647;",
+        "nA = 48271;",
+        "i = 1;",
+        "WHILE( i <= nCells );",
+    ]
+    coords = []
+    for k, size in enumerate(DIM_SIZES.values(), start=1):
+        lines += [
+            "  nState = MOD( nA * nState, nM );",
+            f"  nR = MOD( nState, {size} );",
+            f"  nIdx{k} = INT( nR * nR / {size} );",  # square-skew toward low indices
+        ]
+        coords.append(f"'E' | TRIM(STR(nIdx{k}, 12, 0))")
+    lines += [
+        "  nState = MOD( nA * nState, nM );",
+        f"  nMeas = MOD( nState, {len(MEASURES)} );",
+        "  IF( nMeas = 0 ); sMeas = 'Value'; ELSEIF( nMeas = 1 ); sMeas = 'Count'; ELSE; sMeas = 'Amount'; ENDIF;",
+        "  nState = MOD( nA * nState, nM );",
+        "  nVal = MOD( nState, 1000000 ) + 1;",
+        f"  CellPutN( nVal, sCube, {', '.join(coords)}, sMeas );",
+        "  i = i + 1;",
+        "END;",
+    ]
+    return lines
+
+
+def setup_instance(tm1: TM1Service):
+    _build_dimensions(tm1)
+    _build_cube(tm1)
+    # Server-side fill (avoids the client->server request-memory cap on v12).
+    tm1.processes.execute_ti_code(_ti_fill_prolog())
+
+
+def teardown_instance(tm1: TM1Service):
+    if tm1.cubes.exists(CUBE):
+        tm1.cubes.delete(CUBE)
+    for dim in _dimension_names():
+        if tm1.dimensions.exists(dim):
+            tm1.dimensions.delete(dim)
+
+
+# --- Reads ------------------------------------------------------------------
+
+def read_baseline(tm1: TM1Service, is_v12: bool) -> dict:
+    """Settle cube_memory_used, then report raw value + Unit and converted bytes.
+
+    Polls until the value plateaus so both versions are measured on a settled cube
+    (is_v12 is accepted for call-site symmetry; the settle is version-neutral here).
+    """
+    best = None
+    raw = None
+    for attempt in range(_SETTLE_ATTEMPTS):
+        rows = tm1.metrics.by_cube(cube=CUBE)
+        row = next((r for r in rows
+                    if r.get("Metric") == CUBE_MEMORY_METRIC and r.get("Value") is not None), None)
+        if row is not None:
+            b = unit_to_bytes(row.get("Value"), row.get("Unit"))
+            raw = row
+            if best is not None and b <= best * (1 + _SETTLE_TOLERANCE):
+                best = max(best, b)
+                break
+            best = b if best is None else max(best, b)
+        if attempt < _SETTLE_ATTEMPTS - 1:
+            time.sleep(_SETTLE_WAIT_SECONDS)
+    return {
+        "raw_value": None if raw is None else raw.get("Value"),
+        "raw_unit": None if raw is None else raw.get("Unit"),
+        "bytes": best,
+    }
+
+
+# --- Mode runs --------------------------------------------------------------
+
+MODE_CONFIGS = {
+    "greedy": {"executions": 1, "output": "csv"},
+    "greedy_fast": {"executions": 1, "output": "csv", "fast": True},
+    "predefined": {"executions": 1, "output": "csv", "predefined_orders": "PREDEFINED"},
+    "position_last": {"executions": 1, "output": "csv", "optimize_position": "last"},
+    "dimension": {"executions": 1, "output": "csv", "optimize_dimension": f"{CUBE}_Dim3"},
+    "set": {"executions": 1, "output": "csv", "predefined_orders": "PREDEFINED"},
+}
+
+
+def _cube_config(instance: str, overrides: dict) -> dict:
+    base = {"instance": instance, "cube": CUBE, "views": [], "processes": []}
+    cfg = {**base, **overrides}
+    if cfg.get("predefined_orders") == "PREDEFINED":
+        # one swapped order; reversing the sparse dims is a legal, distinct order
+        sparse = list(DIM_SIZES.keys())
+        cfg["predefined_orders"] = [list(reversed(sparse)) + [MEASURE_DIM]]
+    return cfg
+
+
+def _latest_csv(instance: str) -> str:
+    pattern = str(core.RESULT_PATH / instance / f"{instance}_{CUBE}_*.csv")
+    files = glob.glob(pattern)
+    return max(files, key=os.path.getmtime) if files else None
+
+
+def _parse_result_csv(path: str) -> dict:
+    """Extract winner order + RAM bytes and the original-order baseline bytes."""
+    n_dims = len(_dimension_names())
+    best = None
+    original_ram = None
+    with open(path, newline="") as f:
+        # Result CSVs begin with '# ...' comment lines and a blank line before
+        # the real 'ID,Mode,...' header; drop those so DictReader sees the header.
+        data_lines = [ln for ln in f if ln.strip() and not ln.lstrip().startswith("#")]
+    for row in csv.DictReader(data_lines):
+        order = [row[f"Dimension{i}"] for i in range(1, n_dims + 1)]
+        if (row.get("Mode") or "").upper().startswith("ORIGINAL"):
+            original_ram = float(row["RAM"])
+        if (row.get("Is Best") or "").strip().lower() == "true":
+            best = {"order": order, "ram_bytes": float(row["RAM"])}
+    return {"best": best, "original_ram_bytes": original_ram}
+
+
+def run_modes(instance: str, config_ini: str, password: str) -> dict:
+    results = {}
+    for mode_label, overrides in MODE_CONFIGS.items():
+        tm1_mode = "set" if mode_label == "set" else "optimize"
+        cube_config = _cube_config(instance, overrides)
+        ok = core.main(tm1_mode, cube_config, config_ini, password=password, no_resume=True)
+        csv_path = _latest_csv(instance)
+        parsed = _parse_result_csv(csv_path) if (ok and csv_path) else None
+        results[mode_label] = {"ok": bool(ok), "result": parsed}
+        print(f"    [{instance}] {mode_label}: ok={bool(ok)}")
+    return results
+
+
+# --- Orchestration ----------------------------------------------------------
+
+def process_instance(name: str, config_ini: str, password: str, do_setup: bool) -> dict:
+    cfg = get_tm1_config(config_ini)
+    tm1_args = dict(cfg[name])
+    tm1_args["session_context"] = "optimuspy-parity"
+    if password:
+        tm1_args["password"] = password
+        tm1_args["decode_b64"] = False
+
+    with TM1Service(**tm1_args) as tm1:
+        is_v12 = detect_is_v12(tm1)
+        version = tm1.server.get_product_version()
+        print(f"  {name}: TM1 {version} ({'v12' if is_v12 else 'v11'})")
+        if do_setup:
+            print(f"  {name}: building fixture cube '{CUBE}'...")
+            setup_instance(tm1)
+        baseline = read_baseline(tm1, is_v12)
+        print(f"  {name}: cube_memory_used raw={baseline['raw_value']} "
+              f"{baseline['raw_unit']} -> {baseline['bytes']:.0f} bytes")
+    # mode runs open their own connections via core.main
+    modes = run_modes(name, config_ini, password)
+    return {"version": str(version), "is_v12": is_v12,
+            "baseline": baseline, "modes": modes}
+
+
+def compare(v11: dict, v12: dict) -> bool:
+    print("\n=== PARITY REPORT ===")
+    ok = True
+
+    b11, b12 = v11["baseline"]["bytes"], v12["baseline"]["bytes"]
+    delta = abs(b11 - b12)
+    tol = max(b11, b12) * 0.001  # 0.1% — identical data should be near-identical
+    conv_ok = delta <= tol
+    ok &= conv_ok
+    print(f"\nRAM baseline (Unit->bytes conversion proof):")
+    print(f"  v11: {v11['baseline']['raw_value']} {v11['baseline']['raw_unit']} "
+          f"-> {b11:.0f} bytes")
+    print(f"  v12: {v12['baseline']['raw_value']} {v12['baseline']['raw_unit']} "
+          f"-> {b12:.0f} bytes")
+    print(f"  delta {delta:.0f} bytes ({'PASS' if conv_ok else 'FAIL'}; tol {tol:.0f})")
+
+    print(f"\nMode winner parity:")
+    for mode in MODE_CONFIGS:
+        m11 = v11["modes"].get(mode) or {}
+        m12 = v12["modes"].get(mode) or {}
+        r11, r12 = m11.get("result"), m12.get("result")
+        if not m11.get("ok") or not m12.get("ok") or not r11 or not r12:
+            print(f"  {mode}: FAIL (mode errored or produced no result on one version)")
+            ok = False
+            continue
+        b11, b12 = r11.get("best"), r12.get("best")
+        if b11 is None and b12 is None:
+            # Neither version found an order that beats the original. For an
+            # identical cube that is itself parity — both agree there is no
+            # RAM-improving order — not a failure.
+            print(f"  {mode}: PASS (no improving order on either version)")
+            continue
+        if not b11 or not b12:
+            print(f"  {mode}: FAIL (a winner emerged on one version only)")
+            ok = False
+            continue
+        same = b11["order"] == b12["order"]
+        ok &= same
+        print(f"  {mode}: {'PASS' if same else 'FAIL'}")
+        if not same:
+            print(f"    v11 -> {b11['order']}")
+            print(f"    v12 -> {b12['order']}")
+
+    print(f"\nOVERALL: {'PASS' if ok else 'FAIL'}")
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", default="config/config.ini",
+                    help="path to config.ini (default: config/config.ini)")
+    ap.add_argument("--v11", help="config.ini section name for the v11 instance")
+    ap.add_argument("--v12", help="config.ini section name for the v12 instance")
+    ap.add_argument("--password", default=None, help="password override for both")
+    ap.add_argument("--only", choices=["v11", "v12"], default=None,
+                    help="run against a single instance (for the before/after-change diff)")
+    ap.add_argument("--no-setup", action="store_true",
+                    help="skip cube/data creation (reuse an existing fixture)")
+    ap.add_argument("--cleanup", action="store_true",
+                    help="delete the fixture cube + dimensions when done")
+    ap.add_argument("--snapshot", default=None, help="write results JSON to this path")
+    args = ap.parse_args()
+
+    snapshot = {}
+    do_setup = not args.no_setup
+
+    if args.only != "v12" and args.v11:
+        print("v11 instance:")
+        snapshot["v11"] = process_instance(args.v11, args.config, args.password, do_setup)
+    if args.only != "v11" and args.v12:
+        print("v12 instance:")
+        snapshot["v12"] = process_instance(args.v12, args.config, args.password, do_setup)
+
+    passed = True
+    if "v11" in snapshot and "v12" in snapshot:
+        passed = compare(snapshot["v11"], snapshot["v12"])
+
+    if args.snapshot:
+        Path(args.snapshot).write_text(json.dumps(snapshot, indent=2, sort_keys=True))
+        print(f"\nSnapshot written to {args.snapshot}")
+
+    if args.cleanup:
+        for key, name in (("v11", args.v11), ("v12", args.v12)):
+            if key in snapshot and name:
+                cfg = get_tm1_config(args.config)
+                tm1_args = dict(cfg[name])
+                tm1_args["session_context"] = "optimuspy-parity"
+                if args.password:
+                    tm1_args["password"] = args.password
+                    tm1_args["decode_b64"] = False
+                with TM1Service(**tm1_args) as tm1:
+                    teardown_instance(tm1)
+                    print(f"Cleaned up fixture on {name}")
+
+    sys.exit(0 if passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/optimuspy/core.py
+++ b/src/optimuspy/core.py
@@ -17,6 +17,8 @@ from optimuspy.checkpoint import CheckpointManager
 from optimuspy.executors import (OriginalOrderExecutor, MainExecutor, PredefinedOrderExecutor,
                                  PositionOptimizerExecutor, DimensionOptimizerExecutor,
                                  OptimizationCancelled)
+from optimuspy.metrics import (detect_is_v12, cube_memory_used_bytes, memory_by_cube_bytes,
+                               ram_source_ready)
 from optimuspy.results import ExecutionContext, OptimusResult
 
 APP_NAME = "optimuspy"
@@ -164,36 +166,15 @@ def write_vmm_vmt(tm1: TM1Service, cube_name: str, vmm: str, vmt: str):
     tm1.cells.write_values_through_cellset(mdx, [vmm, vmt])
 
 
-def retrieve_performance_monitor_state(tm1: TM1Service):
-    config = tm1.server.get_active_configuration()
-    return config["Administration"]["PerformanceMonitorOn"]
-
-
-def activate_performance_monitor(tm1: TM1Service):
-    config = {
-        "Administration": {"PerformanceMonitorOn": True}
-    }
-    tm1.server.update_static_configuration(config)
-
-
-def deactivate_performance_monitor(tm1: TM1Service):
-    config = {
-        "Administration": {"PerformanceMonitorOn": False}
-    }
-    tm1.server.update_static_configuration(config)
-
-
 def retrieve_ram_usage(tm1: TM1Service, cube_name: str) -> float:
-    """Retrieve RAM usage for a cube from the performance monitor."""
-    mdx = """
-    SELECT
-    {{ [}}PerfCubes].[{}] }} ON ROWS,
-    {{ [}}StatsStatsByCube].[Total Memory Used] }} ON COLUMNS
-    FROM [}}StatsByCube]
-    WHERE ([}}TimeIntervals].[LATEST])
-    """.format(cube_name)
-    value = list(tm1.cells.execute_mdx_values(mdx=mdx))[0]
-    return float(value) if value else 0.0
+    """Retrieve a cube's RAM in bytes via MetricService (cube_memory_used).
+
+    Best-effort: returns 0.0 when the metric is absent (used only for set-mode
+    before/after logging, which is wrapped in a swallowing try/except).
+    """
+    rows = tm1.metrics.by_cube(cube=cube_name)
+    ram = cube_memory_used_bytes(rows)
+    return ram if ram else 0.0
 
 
 def main(mode: str, cube_config: dict, config_ini_path: str, password: str = None,
@@ -227,6 +208,11 @@ def main(mode: str, cube_config: dict, config_ini_path: str, password: str = Non
         if tm1_holder is not None:
             tm1_holder["tm1"] = tm1
 
+        # Detect the major version once; gates the Performance Monitor lifecycle
+        # and the RAM read-retry behaviour (see optimuspy.metrics).
+        is_v12 = detect_is_v12(tm1)
+        logging.info(f"Connected to TM1 {'v12' if is_v12 else 'v11'} instance '{instance_name}'")
+
         # Validate cube exists
         if not tm1.cubes.exists(cube_name):
             logging.error(f"Cube '{cube_name}' does not exist")
@@ -249,7 +235,7 @@ def main(mode: str, cube_config: dict, config_ini_path: str, password: str = Non
 
         # SET mode: apply order directly, no benchmarking
         if mode == 'set':
-            return _execute_set_mode(tm1, cube_name, predefined_orders[0])
+            return _execute_set_mode(tm1, cube_name, predefined_orders[0], is_v12)
 
         # OPTIMIZE mode
         return _execute_optimize_mode(
@@ -257,7 +243,7 @@ def main(mode: str, cube_config: dict, config_ini_path: str, password: str = Non
             output, update, fast, dimensions_to_exclude, predefined_orders,
             orders_to_ignore, optimize_position, optimize_dimension,
             initial_dimension_order, cube_config, no_resume, tm1_checkpoint,
-            process_parameters, dimension_position_rules, cancel_event)
+            process_parameters, dimension_position_rules, cancel_event, is_v12)
 
 
 def _deduplicate_results(*result_lists):
@@ -271,35 +257,25 @@ def _deduplicate_results(*result_lists):
     return unique
 
 
-def _execute_set_mode(tm1: TM1Service, cube_name: str, target_order: List[str]) -> bool:
+def _execute_set_mode(tm1: TM1Service, cube_name: str, target_order: List[str], is_v12: bool = False) -> bool:
     logging.info(f"SET mode: applying dimension order for cube '{cube_name}' to: {target_order}")
 
-    original_performance_monitor_state = None
+    # Before/after RAM logging is best-effort; never let the RAM source lifecycle
+    # block the actual reorder, which is the primary purpose of set mode.
     ram_before = None
-    try:
-        original_performance_monitor_state = retrieve_performance_monitor_state(tm1)
-        activate_performance_monitor(tm1)
+    with suppress(Exception), ram_source_ready(tm1, is_v12):
         ram_before = retrieve_ram_usage(tm1, cube_name)
-    except Exception:
-        pass
 
-    try:
-        tm1.cubes.update_storage_dimension_order(cube_name, target_order)
-        logging.info(f"Dimension order updated for cube '{cube_name}'")
+    tm1.cubes.update_storage_dimension_order(cube_name, target_order)
+    logging.info(f"Dimension order updated for cube '{cube_name}'")
 
-        try:
-            time.sleep(5)
-            ram_after = retrieve_ram_usage(tm1, cube_name)
-            if ram_before and ram_after:
-                logging.info(f"RAM before: {ram_before / 1024 ** 3:.2f} GB, after: {ram_after / 1024 ** 3:.2f} GB")
-        except Exception:
-            pass
+    with suppress(Exception), ram_source_ready(tm1, is_v12):
+        time.sleep(5)
+        ram_after = retrieve_ram_usage(tm1, cube_name)
+        if ram_before and ram_after:
+            logging.info(f"RAM before: {ram_before / 1024 ** 3:.2f} GB, after: {ram_after / 1024 ** 3:.2f} GB")
 
-        return True
-    finally:
-        with suppress(Exception):
-            if original_performance_monitor_state is not None and not original_performance_monitor_state:
-                deactivate_performance_monitor(tm1)
+    return True
 
 
 def _execute_optimize_mode(tm1: TM1Service, cube_name: str, instance_name: str,
@@ -313,12 +289,13 @@ def _execute_optimize_mode(tm1: TM1Service, cube_name: str, instance_name: str,
                            tm1_checkpoint: bool = False,
                            process_parameters: dict = None,
                            dimension_position_rules: list = None,
-                           cancel_event=None) -> bool:
-    original_performance_monitor_state = retrieve_performance_monitor_state(tm1)
-    activate_performance_monitor(tm1)
-
-    original_vmm, original_vmt = retrieve_vmm_vmt(tm1, cube_name)
-    write_vmm_vmt(tm1, cube_name, "1000000", "1000000")
+                           cancel_event=None, is_v12: bool = False) -> bool:
+    # VMM/VMT live in the }CubeProperties control cube, which only exists on v11.
+    # On v12 those caps are gone, so we neither raise nor restore them there.
+    original_vmm, original_vmt = (None, None)
+    if not is_v12:
+        original_vmm, original_vmt = retrieve_vmm_vmt(tm1, cube_name)
+        write_vmm_vmt(tm1, cube_name, "1000000", "1000000")
 
     displayed_dimension_order = tm1.cubes.get_dimension_names(cube_name=cube_name)
     measure_dimension_only_numeric = is_dimension_only_numeric(tm1, initial_dimension_order[-1])
@@ -365,129 +342,126 @@ def _execute_optimize_mode(tm1: TM1Service, cube_name: str, instance_name: str,
         logging.info("--no-resume specified — ignoring existing checkpoint")
         checkpoint_mgr.remove()
 
-    try:
-        # Benchmark original order (skip if resumed)
-        if original_order_result is None:
-            original_executor = OriginalOrderExecutor(
-                tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
-                measure_dimension_only_numeric, initial_dimension_order, context,
-                checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
-                cancel_event=cancel_event)
-            permutation_results += original_executor.execute()
-            original_order_result = permutation_results[0]
+    with ram_source_ready(tm1, is_v12):
+        try:
+            # Benchmark original order (skip if resumed)
+            if original_order_result is None:
+                original_executor = OriginalOrderExecutor(
+                    tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
+                    measure_dimension_only_numeric, initial_dimension_order, context,
+                    checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
+                    cancel_event=cancel_event, is_v12=is_v12)
+                permutation_results += original_executor.execute()
+                original_order_result = permutation_results[0]
 
-            # Save initial checkpoint with original order result
-            checkpoint_mgr.save(
-                executor_type="OriginalOrderExecutor",
-                execution_context=context,
-                initial_dimension_order=initial_dimension_order,
-                last_applied_order=initial_dimension_order,
-                original_order_result=original_order_result,
-                completed_results=[])
+                # Save initial checkpoint with original order result
+                checkpoint_mgr.save(
+                    executor_type="OriginalOrderExecutor",
+                    execution_context=context,
+                    initial_dimension_order=initial_dimension_order,
+                    last_applied_order=initial_dimension_order,
+                    original_order_result=original_order_result,
+                    completed_results=[])
 
-        # Run iterations: targeted, predefined, or greedy algorithm
-        if optimize_position is not None:
-            resolved_pos = resolve_position(optimize_position, len(displayed_dimension_order))
-            logging.info(f"Optimizing position {resolved_pos + 1} (0-based: {resolved_pos}) "
-                         f"for cube '{cube_name}'")
-            executor = PositionOptimizerExecutor(
-                tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
-                measure_dimension_only_numeric, resolved_pos, context, dimensions_to_exclude,
-                checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
-                cancel_event=cancel_event)
-        elif optimize_dimension:
-            if optimize_dimension not in displayed_dimension_order:
-                raise ValueError(
-                    f"Dimension '{optimize_dimension}' not found in cube '{cube_name}'. "
-                    f"Available: {displayed_dimension_order}")
-            logging.info(f"Optimizing dimension '{optimize_dimension}' for cube '{cube_name}'")
-            executor = DimensionOptimizerExecutor(
-                tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
-                measure_dimension_only_numeric, optimize_dimension, context,
-                checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
-                cancel_event=cancel_event)
-        elif predefined_orders:
-            executor = PredefinedOrderExecutor(
-                tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
-                measure_dimension_only_numeric, predefined_orders, context,
-                checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
-                cancel_event=cancel_event)
-        else:
-            executor = MainExecutor(
-                tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
-                measure_dimension_only_numeric, context, fast, dimensions_to_exclude, orders_to_ignore,
-                checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
-                dimension_position_rules=dimension_position_rules, cancel_event=cancel_event)
-
-        # Set resume context on executor
-        executor.set_resume_context(initial_dimension_order, original_order_result, resumed_results)
-
-        # Execute (with resume state if available)
-        new_results = executor.execute(resume_state=resume_state)
-        permutation_results += new_results
-
-        # Combine resumed + new results for final analysis
-        unique_results = _deduplicate_results(
-            [original_order_result], resumed_results, permutation_results)
-
-        optimus_result = OptimusResult(cube_name, unique_results, instance_name=instance_name)
-        best_permutation = optimus_result.best_result
-        logging.info(f"Completed analysis for cube '{cube_name}'")
-
-        if not best_permutation:
-            tm1.cubes.update_storage_dimension_order(cube_name, initial_dimension_order)
-            logging.info(
-                f"No ideal dimension order found for cube '{cube_name}'. "
-                f"Restored original order to {initial_dimension_order}. "
-                f"Please pick manually based on results.")
-        else:
-            best_order = best_permutation.dimension_order
-            if update:
-                tm1.cubes.update_storage_dimension_order(cube_name, best_order)
-                logging.info(f"Updated dimension order for cube '{cube_name}' to {best_order}")
+            # Run iterations: targeted, predefined, or greedy algorithm
+            if optimize_position is not None:
+                resolved_pos = resolve_position(optimize_position, len(displayed_dimension_order))
+                logging.info(f"Optimizing position {resolved_pos + 1} (0-based: {resolved_pos}) "
+                             f"for cube '{cube_name}'")
+                executor = PositionOptimizerExecutor(
+                    tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
+                    measure_dimension_only_numeric, resolved_pos, context, dimensions_to_exclude,
+                    checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
+                    cancel_event=cancel_event, is_v12=is_v12)
+            elif optimize_dimension:
+                if optimize_dimension not in displayed_dimension_order:
+                    raise ValueError(
+                        f"Dimension '{optimize_dimension}' not found in cube '{cube_name}'. "
+                        f"Available: {displayed_dimension_order}")
+                logging.info(f"Optimizing dimension '{optimize_dimension}' for cube '{cube_name}'")
+                executor = DimensionOptimizerExecutor(
+                    tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
+                    measure_dimension_only_numeric, optimize_dimension, context,
+                    checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
+                    cancel_event=cancel_event, is_v12=is_v12)
+            elif predefined_orders:
+                executor = PredefinedOrderExecutor(
+                    tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
+                    measure_dimension_only_numeric, predefined_orders, context,
+                    checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
+                    cancel_event=cancel_event, is_v12=is_v12)
             else:
-                logging.info(f"Best order for cube '{cube_name}': {best_order}")
+                executor = MainExecutor(
+                    tm1, cube_name, view_names, process_names, displayed_dimension_order, executions,
+                    measure_dimension_only_numeric, context, fast, dimensions_to_exclude, orders_to_ignore,
+                    checkpoint_manager=checkpoint_mgr, process_parameters=process_parameters,
+                    dimension_position_rules=dimension_position_rules, cancel_event=cancel_event,
+                    is_v12=is_v12)
+
+            # Set resume context on executor
+            executor.set_resume_context(initial_dimension_order, original_order_result, resumed_results)
+
+            # Execute (with resume state if available)
+            new_results = executor.execute(resume_state=resume_state)
+            permutation_results += new_results
+
+            # Combine resumed + new results for final analysis
+            unique_results = _deduplicate_results(
+                [original_order_result], resumed_results, permutation_results)
+
+            optimus_result = OptimusResult(cube_name, unique_results, instance_name=instance_name)
+            best_permutation = optimus_result.best_result
+            logging.info(f"Completed analysis for cube '{cube_name}'")
+
+            if not best_permutation:
                 tm1.cubes.update_storage_dimension_order(cube_name, initial_dimension_order)
-                logging.info(f"Restored original dimension order for cube '{cube_name}'")
-
-        # Success — remove checkpoint
-        checkpoint_mgr.remove()
-
-    except OptimizationCancelled:
-        raise  # Let caller (JobManager) handle cancellation cleanly
-    except Exception as e:
-        logging.error(f"Fatal error: {e}", exc_info=True)
-        logging.info("Re-run the same command to resume from checkpoint")
-        return False
-
-    finally:
-        with suppress(Exception):
-            write_vmm_vmt(tm1, cube_name, original_vmm, original_vmt)
-
-        with suppress(Exception):
-            if original_performance_monitor_state:
-                activate_performance_monitor(tm1)
+                logging.info(
+                    f"No ideal dimension order found for cube '{cube_name}'. "
+                    f"Restored original order to {initial_dimension_order}. "
+                    f"Please pick manually based on results.")
             else:
-                deactivate_performance_monitor(tm1)
+                best_order = best_permutation.dimension_order
+                if update:
+                    tm1.cubes.update_storage_dimension_order(cube_name, best_order)
+                    logging.info(f"Updated dimension order for cube '{cube_name}' to {best_order}")
+                else:
+                    logging.info(f"Best order for cube '{cube_name}': {best_order}")
+                    tm1.cubes.update_storage_dimension_order(cube_name, initial_dimension_order)
+                    logging.info(f"Restored original dimension order for cube '{cube_name}'")
 
-        # Build results from whatever we have (resumed + new)
-        unique_for_output = _deduplicate_results(
-            [original_order_result], resumed_results, permutation_results)
+            # Success — remove checkpoint
+            checkpoint_mgr.remove()
 
-        if unique_for_output:
-            if optimus_result is None:
-                optimus_result = OptimusResult(cube_name, unique_for_output, instance_name=instance_name)
-            else:
-                optimus_result.instance_name = instance_name
-            file_base = RESULT_FILENAME.format(instance_name, cube_name, TIME_STAMP)
-            instance_dir = RESULT_PATH / instance_name
+        except OptimizationCancelled:
+            raise  # Let caller (JobManager) handle cancellation cleanly
+        except Exception as e:
+            logging.error(f"Fatal error: {e}", exc_info=True)
+            logging.info("Re-run the same command to resume from checkpoint")
+            return False
 
-            optimus_result.to_html(instance_dir / f"{file_base}.html", total_duration=context.elapsed)
+        finally:
+            if not is_v12:
+                with suppress(Exception):
+                    write_vmm_vmt(tm1, cube_name, original_vmm, original_vmt)
 
-            if output.upper() == "XLSX":
-                optimus_result.to_xlsx(instance_dir / f"{file_base}.xlsx")
-            else:
-                optimus_result.to_csv(instance_dir / f"{file_base}.csv")
+            # Build results from whatever we have (resumed + new)
+            unique_for_output = _deduplicate_results(
+                [original_order_result], resumed_results, permutation_results)
+
+            if unique_for_output:
+                if optimus_result is None:
+                    optimus_result = OptimusResult(cube_name, unique_for_output, instance_name=instance_name)
+                else:
+                    optimus_result.instance_name = instance_name
+                file_base = RESULT_FILENAME.format(instance_name, cube_name, TIME_STAMP)
+                instance_dir = RESULT_PATH / instance_name
+
+                optimus_result.to_html(instance_dir / f"{file_base}.html", total_duration=context.elapsed)
+
+                if output.upper() == "XLSX":
+                    optimus_result.to_xlsx(instance_dir / f"{file_base}.xlsx")
+                else:
+                    optimus_result.to_csv(instance_dir / f"{file_base}.csv")
 
     return True
 
@@ -572,36 +546,15 @@ def _collect_dimension_metadata(tm1: TM1Service, dimension_names: list) -> list:
 
 
 def _scan_to_data(tm1: TM1Service, instance_name: str, ram_threshold_pct: int = 60,
-                   include_optimized: bool = False) -> dict:
+                   include_optimized: bool = False, is_v12: bool = False) -> dict:
     """Core scan logic — returns structured data. Used by both CLI and UI."""
-    original_perf_state = None
-    try:
-        original_perf_state = retrieve_performance_monitor_state(tm1)
-        activate_performance_monitor(tm1)
-
-        # Single MDX: get RAM for all non-control cubes (includes 'Cubes Total' row)
-        mdx = """
-        SELECT
-          NON EMPTY {[}StatsStatsByCube].[}StatsStatsByCube].[Total Memory Used]} ON COLUMNS,
-          NON EMPTY EXCEPT(
-            {TM1SUBSETALL([}PerfCubes].[}PerfCubes])},
-            {TM1FILTERBYPATTERN({TM1SUBSETALL([}PerfCubes].[}PerfCubes])}, "}*")}
-          ) ON ROWS
-        FROM [}StatsByCube]
-        WHERE ([}TimeIntervals].[}TimeIntervals].[LATEST])
-        """
-        df = tm1.cells.execute_mdx_dataframe(mdx)
-
-        ram_by_cube = {}
-        for _, row in df.iterrows():
-            cube = str(row["}PerfCubes"])
-            if cube == "Cubes Total":
-                continue
-            try:
-                ram_value = float(row["Value"])
-            except (ValueError, TypeError):
-                continue
-            ram_by_cube[cube] = ram_value
+    with ram_source_ready(tm1, is_v12):
+        # Single round-trip: cube_memory_used (bytes) for all non-control cubes.
+        # by_cube() already excludes }-control cubes and the synthetic 'Cubes Total'
+        # row on both v11 and v12, and converts each value to bytes by its Unit —
+        # so OptimusPy's old EXCEPT/TM1FILTERBYPATTERN("}*") and Cubes-Total skip
+        # logic is no longer needed.
+        ram_by_cube = memory_by_cube_bytes(tm1.metrics.by_cube())
 
         total_model_ram = sum(ram_by_cube.values())
         if total_model_ram <= 0:
@@ -652,11 +605,6 @@ def _scan_to_data(tm1: TM1Service, instance_name: str, ram_threshold_pct: int = 
                 "suggested_order": suggested,
             })
 
-    finally:
-        with suppress(Exception):
-            if original_perf_state is not None and not original_perf_state:
-                deactivate_performance_monitor(tm1)
-
     return {
         "total_model_ram": total_model_ram,
         "total_model_ram_gb": total_model_ram / (1024 ** 3),
@@ -665,41 +613,18 @@ def _scan_to_data(tm1: TM1Service, instance_name: str, ram_threshold_pct: int = 
 
 
 def _scan_to_data_light(tm1: TM1Service, instance_name: str, ram_threshold_pct: int = 60,
-                        include_optimized: bool = False) -> dict:
+                        include_optimized: bool = False, is_v12: bool = False) -> dict:
     """Lightweight scan — RAM + dimension names + storage order + last-dim string check only.
 
     Skips the expensive per-dimension metadata collection (_collect_dimension_metadata).
     Per cube: get_dimension_names (1 call) + get_storage_dimension_order (1 call)
               + get_number_of_string_elements for last dim only (1 call) = 3 API calls.
     """
-    original_perf_state = None
-    try:
-        original_perf_state = retrieve_performance_monitor_state(tm1)
-        activate_performance_monitor(tm1)
-
-        # Single MDX: get RAM for all non-control cubes
-        mdx = """
-        SELECT
-          NON EMPTY {[}StatsStatsByCube].[}StatsStatsByCube].[Total Memory Used]} ON COLUMNS,
-          NON EMPTY EXCEPT(
-            {TM1SUBSETALL([}PerfCubes].[}PerfCubes])},
-            {TM1FILTERBYPATTERN({TM1SUBSETALL([}PerfCubes].[}PerfCubes])}, "}*")}
-          ) ON ROWS
-        FROM [}StatsByCube]
-        WHERE ([}TimeIntervals].[}TimeIntervals].[LATEST])
-        """
-        df = tm1.cells.execute_mdx_dataframe(mdx)
-
-        ram_by_cube = {}
-        for _, row in df.iterrows():
-            cube = str(row["}PerfCubes"])
-            if cube == "Cubes Total":
-                continue
-            try:
-                ram_value = float(row["Value"])
-            except (ValueError, TypeError):
-                continue
-            ram_by_cube[cube] = ram_value
+    with ram_source_ready(tm1, is_v12):
+        # Single round-trip: cube_memory_used (bytes) for all non-control cubes.
+        # by_cube() already excludes }-control cubes and the synthetic 'Cubes Total'
+        # row on both v11 and v12, and converts each value to bytes by its Unit.
+        ram_by_cube = memory_by_cube_bytes(tm1.metrics.by_cube())
 
         total_model_ram = sum(ram_by_cube.values())
         if total_model_ram <= 0:
@@ -755,11 +680,6 @@ def _scan_to_data_light(tm1: TM1Service, instance_name: str, ram_threshold_pct: 
                 "last_dim_has_strings": last_dim_has_strings,
             })
 
-    finally:
-        with suppress(Exception):
-            if original_perf_state is not None and not original_perf_state:
-                deactivate_performance_monitor(tm1)
-
     return {
         "total_model_ram": total_model_ram,
         "total_model_ram_gb": total_model_ram / (1024 ** 3),
@@ -771,8 +691,10 @@ def _execute_scan_mode(tm1: TM1Service, instance_name: str, ram_threshold_pct: i
                        output_dir: str = None) -> bool:
     logging.info(f"Scanning instance '{instance_name}' for optimization candidates...")
 
+    is_v12 = detect_is_v12(tm1)
+
     try:
-        data = _scan_to_data(tm1, instance_name, ram_threshold_pct)
+        data = _scan_to_data(tm1, instance_name, ram_threshold_pct, is_v12=is_v12)
     except ValueError as e:
         logging.error(str(e))
         return False

--- a/src/optimuspy/executors.py
+++ b/src/optimuspy/executors.py
@@ -7,6 +7,7 @@ from typing import List, Dict
 from TM1py import TM1Service, Process
 
 from optimuspy.execution_mode import ExecutionMode
+from optimuspy.metrics import read_cube_memory_bytes
 from optimuspy.results import ExecutionContext, PermutationResult
 
 
@@ -30,7 +31,8 @@ class OptipyzerExecutor:
     def __init__(self, tm1: TM1Service, cube_name: str, view_names: List[str], process_names: List[str],
                  displayed_dimension_order: List[str],
                  executions: int, measure_dimension_only_numeric: bool, context: ExecutionContext,
-                 checkpoint_manager=None, process_parameters: dict = None, cancel_event=None):
+                 checkpoint_manager=None, process_parameters: dict = None, cancel_event=None,
+                 is_v12: bool = False):
         self.tm1 = tm1
         self.cube_name = cube_name
         self.view_names = view_names
@@ -38,6 +40,7 @@ class OptipyzerExecutor:
         self.dimensions = displayed_dimension_order
         self.executions = executions
         self.measure_dimension_only_numeric = measure_dimension_only_numeric
+        self.is_v12 = is_v12
         self.mode = None
         self.include_process = bool(process_names)
         self.cube_dim_number = len(self.dimensions)
@@ -129,24 +132,9 @@ class OptipyzerExecutor:
         return permutation_result
 
     def _retrieve_ram_usage(self):
-        number_of_iterations = 4
-        for i in range(number_of_iterations):
-            mdx = """
-            SELECT
-            {{ [}}PerfCubes].[{}] }} ON ROWS,
-            {{ [}}StatsStatsByCube].[Total Memory Used] }} ON COLUMNS
-            FROM [}}StatsByCube]
-            WHERE ([}}TimeIntervals].[LATEST])
-            """.format(self.cube_name)
-            value = list(self.tm1.cells.execute_mdx_values(mdx=mdx))[0]
-            if value:
-                return value
-
-            logging.info("Failed to retrieve RAM consumption. Waiting 15s before retry")
-            if i < number_of_iterations - 1:
-                time.sleep(15)
-
-        raise RuntimeError("Performance Monitor must be activated")
+        # RAM baseline in bytes via MetricService (cube_memory_used), version-agnostic.
+        # v11 keeps the read-retry loop; v12 fails fast (see read_cube_memory_bytes).
+        return read_cube_memory_bytes(self.tm1, self.cube_name, self.is_v12)
 
     def _has_string_elements(self, dimension_name: str) -> bool:
         hierarchy_name = "Leaves" if self.tm1.hierarchies.exists(
@@ -184,10 +172,10 @@ class OriginalOrderExecutor(OptipyzerExecutor):
                  dimensions: List[str], executions: int,
                  measure_dimension_only_numeric: bool, original_dimension_order: List[str],
                  context: ExecutionContext, checkpoint_manager=None, process_parameters: dict = None,
-                 cancel_event=None):
+                 cancel_event=None, is_v12: bool = False):
         super().__init__(tm1, cube_name, view_names, process_names, dimensions, executions,
                          measure_dimension_only_numeric, context, checkpoint_manager, process_parameters,
-                         cancel_event)
+                         cancel_event, is_v12=is_v12)
         self.mode = ExecutionMode.ORIGINAL_ORDER
         self.original_dimension_order = original_dimension_order
 
@@ -207,10 +195,10 @@ class MainExecutor(OptipyzerExecutor):
                  dimensions_to_exclude: List[str] = None,
                  orders_to_ignore: List[List[str]] = None,
                  checkpoint_manager=None, process_parameters: dict = None,
-                 dimension_position_rules: list = None, cancel_event=None):
+                 dimension_position_rules: list = None, cancel_event=None, is_v12: bool = False):
         super().__init__(tm1, cube_name, view_names, process_names, dimensions, executions,
                          measure_dimension_only_numeric, context, checkpoint_manager, process_parameters,
-                         cancel_event)
+                         cancel_event, is_v12=is_v12)
         self.mode = ExecutionMode.ITERATIONS
         self.fast = fast
         self.dimensions_to_exclude = dimensions_to_exclude or []
@@ -387,10 +375,10 @@ class PredefinedOrderExecutor(OptipyzerExecutor):
                  dimensions: List[str], executions: int,
                  measure_dimension_only_numeric: bool, predefined_orders: List[List[str]],
                  context: ExecutionContext, checkpoint_manager=None, process_parameters: dict = None,
-                 cancel_event=None):
+                 cancel_event=None, is_v12: bool = False):
         super().__init__(tm1, cube_name, view_names, process_names, dimensions, executions,
                          measure_dimension_only_numeric, context, checkpoint_manager, process_parameters,
-                         cancel_event)
+                         cancel_event, is_v12=is_v12)
         self.mode = ExecutionMode.ITERATIONS
         self.predefined_orders = predefined_orders
 
@@ -431,10 +419,10 @@ class PositionOptimizerExecutor(OptipyzerExecutor):
                  dimensions: List[str], executions: int, measure_dimension_only_numeric: bool,
                  target_position: int, context: ExecutionContext,
                  dimensions_to_exclude: List[str] = None, checkpoint_manager=None,
-                 process_parameters: dict = None, cancel_event=None):
+                 process_parameters: dict = None, cancel_event=None, is_v12: bool = False):
         super().__init__(tm1, cube_name, view_names, process_names, dimensions, executions,
                          measure_dimension_only_numeric, context, checkpoint_manager, process_parameters,
-                         cancel_event)
+                         cancel_event, is_v12=is_v12)
         self.mode = ExecutionMode.ITERATIONS
         self.target_position = target_position
         self.dimensions_to_exclude = dimensions_to_exclude or []
@@ -489,10 +477,10 @@ class DimensionOptimizerExecutor(OptipyzerExecutor):
     def __init__(self, tm1: TM1Service, cube_name: str, view_names: List[str], process_names: List[str],
                  dimensions: List[str], executions: int, measure_dimension_only_numeric: bool,
                  target_dimension: str, context: ExecutionContext, checkpoint_manager=None,
-                 process_parameters: dict = None, cancel_event=None):
+                 process_parameters: dict = None, cancel_event=None, is_v12: bool = False):
         super().__init__(tm1, cube_name, view_names, process_names, dimensions, executions,
                          measure_dimension_only_numeric, context, checkpoint_manager, process_parameters,
-                         cancel_event)
+                         cancel_event, is_v12=is_v12)
         self.mode = ExecutionMode.ITERATIONS
         self.target_dimension = target_dimension
 

--- a/src/optimuspy/metrics.py
+++ b/src/optimuspy/metrics.py
@@ -1,0 +1,170 @@
+"""Version-agnostic per-cube RAM source backed by TM1py's MetricService.
+
+OptimusPy reads a cube's memory (the ``cube_memory_used`` metric) from
+``tm1.metrics`` (TM1py >= 2.3.0) on both TM1 v11 and v12, replacing the
+v11-only ``}StatsByCube`` control-cube MDX lookups.
+
+MetricService normalises metric *names* across versions but **not** their
+units: ``cube_memory_used`` is reported in ``B`` on v11 and ``KB`` on v12.
+Every value is converted to bytes at this read boundary so all downstream
+``/ 1024 ** 3`` GB math is unchanged. An unknown unit fails loud — the raw
+number is never passed through, because a silent unit change would corrupt
+every RAM comparison OptimusPy makes.
+"""
+import logging
+import time
+from contextlib import contextmanager, suppress
+
+# Canonical MetricService metric name for a cube's total memory (both versions).
+CUBE_MEMORY_METRIC = "cube_memory_used"
+
+# MetricService 'Unit' tag -> multiplier to bytes. Do not "simplify" this to a
+# hardcoded x1024: the whole point of reading Unit is to stay correct when the
+# server reports a different unit (B on v11, KB on v12, and so on).
+_UNIT_TO_BYTES = {
+    "B": 1,
+    "KB": 1024,
+    "MB": 1024 ** 2,
+}
+
+# v11 read-retry loop: the Performance Monitor samples on an interval, so the
+# metric can be empty for a short window right after activation. v11 behaviour is
+# frozen — this retry-on-empty is unchanged from the }StatsByCube era.
+_V11_RETRY_ATTEMPTS = 4
+_V11_RETRY_WAIT_SECONDS = 15
+
+# v12 stabilization: cube_memory_used is a sampled gauge that lags right after a
+# data change — it can report a too-small value before catching up. We can't know
+# the cube's true size in advance, so we poll until the value plateaus (a re-read
+# no longer materially larger than the largest seen). On a settled, resident cube
+# the second read confirms the first and this returns immediately; only just after
+# a bulk load does it wait. The winner is derived from %-deltas and is correct
+# regardless, so if it never fully settles we return the largest sample seen.
+_V12_STABILIZE_ATTEMPTS = 6
+_V12_STABILIZE_WAIT_SECONDS = 10
+_V12_STABILIZE_TOLERANCE = 0.01  # 1% — a read within this of the max is "plateaued"
+
+
+def detect_is_v12(tm1) -> bool:
+    """Return True if the connected TM1 server is v12+.
+
+    Parse this once per connection and thread the boolean down; it gates the
+    Performance Monitor lifecycle and the read-retry behaviour.
+    """
+    version = tm1.server.get_product_version()
+    major = int(str(version).split(".")[0])
+    return major >= 12
+
+
+def unit_to_bytes(value, unit) -> float:
+    """Convert a MetricService memory value to bytes using its reported Unit.
+
+    Fails loud on an unknown unit — never passes the raw number through.
+    """
+    try:
+        multiplier = _UNIT_TO_BYTES[unit]
+    except KeyError:
+        raise RuntimeError(
+            f"Unknown Unit '{unit}' for {CUBE_MEMORY_METRIC}; "
+            f"expected one of {sorted(_UNIT_TO_BYTES)}. Refusing to pass the "
+            f"value through unconverted.")
+    return float(value) * multiplier
+
+
+def cube_memory_used_bytes(rows) -> float:
+    """Pick the cube_memory_used row from a single-cube ``by_cube()`` result, in bytes.
+
+    Returns None if the metric is absent or has no value, so the caller can
+    decide whether that is a hard error (v12) or retry-worthy (v11).
+    """
+    for row in rows:
+        if row.get("Metric") != CUBE_MEMORY_METRIC:
+            continue
+        value = row.get("Value")
+        if value is None:
+            return None
+        return unit_to_bytes(value, row.get("Unit"))
+    return None
+
+
+def memory_by_cube_bytes(rows) -> dict:
+    """Pivot unfiltered ``by_cube()`` rows to ``{cube_name: bytes}`` for cube_memory_used.
+
+    ``by_cube()`` already excludes ``}``-control cubes and the synthetic
+    ``Cubes Total`` row on both versions, so no manual filtering is needed.
+    """
+    result = {}
+    for row in rows:
+        if row.get("Metric") != CUBE_MEMORY_METRIC:
+            continue
+        value = row.get("Value")
+        if value is None:
+            continue
+        cube = row.get("CubeName")
+        if not cube:
+            continue
+        result[cube] = unit_to_bytes(value, row.get("Unit"))
+    return result
+
+
+def read_cube_memory_bytes(tm1, cube_name: str, is_v12: bool) -> float:
+    """Read one cube's RAM baseline in bytes via MetricService.
+
+    v11: retry the read (the Performance Monitor populates on an interval), then
+    fail with the historical "Performance Monitor must be activated" message.
+    v12: an absent metric is a hard error, but a present value is read until it
+    plateaus — the gauge can lag right after a data change (see the stabilization
+    note above), so we wait for it to settle rather than trust the first sample.
+    """
+    if is_v12:
+        best = None
+        for attempt in range(_V12_STABILIZE_ATTEMPTS):
+            rows = tm1.metrics.by_cube(cube=cube_name)
+            ram = cube_memory_used_bytes(rows)
+            if ram is None:
+                raise RuntimeError(
+                    f"No {CUBE_MEMORY_METRIC} reported for cube '{cube_name}' — "
+                    f"metric unavailable or cube not yet populated.")
+            # Plateaued: this read is not materially larger than the largest seen.
+            if best is not None and ram <= best * (1 + _V12_STABILIZE_TOLERANCE):
+                return max(best, ram)
+            best = ram if best is None else max(best, ram)
+            if attempt < _V12_STABILIZE_ATTEMPTS - 1:
+                logging.info("v12 cube_memory_used still rising; waiting for it to settle")
+                time.sleep(_V12_STABILIZE_WAIT_SECONDS)
+        return best
+
+    for attempt in range(_V11_RETRY_ATTEMPTS):
+        rows = tm1.metrics.by_cube(cube=cube_name)
+        ram = cube_memory_used_bytes(rows)
+        if ram:
+            return ram
+
+        logging.info("Failed to retrieve RAM consumption. Waiting 15s before retry")
+        if attempt < _V11_RETRY_ATTEMPTS - 1:
+            time.sleep(_V11_RETRY_WAIT_SECONDS)
+
+    raise RuntimeError("Performance Monitor must be activated")
+
+
+@contextmanager
+def ram_source_ready(tm1, is_v12: bool):
+    """Ensure cube_memory_used is readable for the duration of the block.
+
+    v11: capture the Performance Monitor's prior state, activate it if it was
+    off, and restore the prior state on exit (via the v11-only ``tm1.metrics``
+    lifecycle methods).
+    v12: no-op — the metric is always available and those lifecycle methods
+    raise on v12.
+    """
+    prior_state = None
+    if not is_v12:
+        prior_state = tm1.metrics.get_performance_monitor_state()
+        if not prior_state:
+            tm1.metrics.start_performance_monitor()
+    try:
+        yield
+    finally:
+        if not is_v12 and prior_state is not None and not prior_state:
+            with suppress(Exception):
+                tm1.metrics.stop_performance_monitor()

--- a/src/optimuspy/ui.py
+++ b/src/optimuspy/ui.py
@@ -29,6 +29,7 @@ from optimuspy.core import (
     set_current_directory, _collect_dimension_metadata, _compute_suggested_order
 )
 from optimuspy.executors import OptimizationCancelled
+from optimuspy.metrics import detect_is_v12
 
 DEFAULT_PORT = 8765
 DEFAULT_CONFIG_INI = "config/config.ini"
@@ -646,7 +647,8 @@ class OptimusPyHandler(BaseHTTPRequestHandler):
             return self._send_json(400, {"error": "Missing 'instance'"})
         try:
             with _create_tm1_connection(instance, password) as tm1:
-                data = _scan_to_data_light(tm1, instance, ram_percent, include_optimized)
+                is_v12 = detect_is_v12(tm1)
+                data = _scan_to_data_light(tm1, instance, ram_percent, include_optimized, is_v12=is_v12)
                 self._send_json(200, data)
         except Exception as e:
             self._send_json(500, {"error": f"Scan failed: {e}"})
@@ -919,7 +921,8 @@ class OptimusPyHandler(BaseHTTPRequestHandler):
             return self._send_json(400, {"error": "Missing 'instance'"})
         try:
             with _create_tm1_connection(instance, password) as tm1:
-                data = _scan_to_data_light(tm1, instance, ram_percent, include_optimized=True)
+                is_v12 = detect_is_v12(tm1)
+                data = _scan_to_data_light(tm1, instance, ram_percent, include_optimized=True, is_v12=is_v12)
                 self._send_json(200, data)
         except Exception as e:
             self._send_json(500, {"error": f"Scan failed: {e}"})


### PR DESCRIPTION
Replace the v11-only }StatsByCube MDX reads with TM1py 2.3.0's version-agnostic MetricService (cube_memory_used) so OptimusPy runs on both TM1 v11 and v12 (}StatsByCube was removed in v12).

- New src/optimuspy/metrics.py read-boundary seam: converts each value to bytes by its reported Unit (B/KB/MB; unknown unit fails loud), detects the major version once via get_product_version(), and owns the single-cube read, the all-cubes pivot, and the Performance Monitor lifecycle.
- Swap every RAM read (executor baseline, core single-cube, both scan pivots) to MetricService; drop manual }*-control / "Cubes Total" filtering (by_cube already excludes them).
- Version-gate v11-only behaviour: Performance Monitor toggling, the retry-on-empty loop, and the VMM/VMT cap raise/restore (}CubeProperties is gone in v12). v11 behaviour is otherwise frozen.
- v12 cube_memory_used is a sampled gauge that lags after a data change; the v12 read waits for the value to plateau before trusting it.
- Pin TM1py>=2.3.0; reword the }StatsByCube doc references; add a supported- versions line; record the decision in docs/adr/0001 and CONTEXT.md.
- Add samples/validate_v11_v12_parity.py: live two-instance gate proving Unit->bytes parity and behaviour equivalence (validated on 11.8 + 12.5.9).