### PR TITLE
feat(ui): pin optimuspy.log to <install dir>/logs regardless of CWD

### DIFF
--- a/src/optimuspy/core.py
+++ b/src/optimuspy/core.py
@@ -41,6 +41,30 @@ def set_current_directory():
     return directory
 
 
+def get_app_base_dir() -> Path:
+    """Return the application's install directory.
+
+    For a PyInstaller frozen build this is the directory containing the executable;
+    for a source/repo run it is the project root (two levels above this package:
+    src/optimuspy/core.py -> repo root).
+    """
+    if getattr(sys, 'frozen', False):
+        return Path(sys.executable).resolve().parent
+    return Path(__file__).resolve().parents[2]
+
+
+def get_logfile_path() -> Path:
+    """Resolve the optimuspy.log path under a logs/ directory in the install dir.
+
+    Pinned to the install directory (see get_app_base_dir), so the log always lands
+    in the same place regardless of the current working directory or a relative config
+    path. The logs/ directory is created if it does not exist.
+    """
+    logs_dir = get_app_base_dir() / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    return logs_dir / LOGFILE
+
+
 def configure_logging():
     logging.basicConfig(
         filename=LOGFILE,

--- a/src/optimuspy/ui.py
+++ b/src/optimuspy/ui.py
@@ -25,7 +25,7 @@ from TM1py import TM1Service
 
 from optimuspy.core import (
     get_tm1_config, validate_cube_config,
-    main as run_optimuspy, _scan_to_data_light, APP_NAME, RESULT_PATH,
+    main as run_optimuspy, _scan_to_data_light, APP_NAME, get_logfile_path, RESULT_PATH,
     set_current_directory, _collect_dimension_metadata, _compute_suggested_order
 )
 from optimuspy.executors import OptimizationCancelled
@@ -1085,11 +1085,15 @@ def main():
     if getattr(sys, 'frozen', False):
         set_current_directory()
 
-    # Configure logging
+    # Configure logging: write to <install dir>/logs/optimuspy.log and echo to the console
+    log_path = get_logfile_path()
     logging.basicConfig(
         format="%(asctime)s - optimuspy-ui - %(levelname)s - %(message)s",
         level=logging.INFO,
-        stream=sys.stdout,
+        handlers=[
+            logging.FileHandler(log_path, encoding="utf-8"),
+            logging.StreamHandler(sys.stdout),
+        ],
     )
 
     server = HTTPServer(('127.0.0.1', args.port), OptimusPyHandler)
@@ -1099,6 +1103,7 @@ def main():
     print(f"  {'─' * 40}")
     print(f"  URL:        {url}")
     print(f"  Config:     {_config_ini_path}")
+    print(f"  Log:        {log_path}")
     print("  Press Ctrl+C to stop\n")
 
     # Auto-open browser


### PR DESCRIPTION
The UI previously logged only to stdout, so no optimuspy.log file was ever created. Add get_app_base_dir()/get_logfile_path() in core and use them in the UI to write logs/optimuspy.log anchored to the install directory (exe folder when frozen, repo root otherwise), independent of the current working directory and the config path. Keep console output and surface the path in the banner.